### PR TITLE
modified InternalLinkProps to include children and className

### DIFF
--- a/src/lib/router-events/patch-router/link.tsx
+++ b/src/lib/router-events/patch-router/link.tsx
@@ -8,7 +8,7 @@ import { shouldTriggerStartEvent } from './should-trigger-start-event';
 
 type ExtendedLinkProps<RouteInferType = any> = LinkProps & {
 	className?: string;
-	children?: ReactNode;
+	children?: ReactNode | string;
 };
 
 export const Link = forwardRef<HTMLAnchorElement, ExtendedLinkProps>(function Link(

--- a/src/lib/router-events/patch-router/link.tsx
+++ b/src/lib/router-events/patch-router/link.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import NextLink, { LinkProps } from 'next/link';
-import { forwardRef } from 'react';
+import { forwardRef, ReactNode } from 'react';
 
 import { onStart } from '../events';
 import { shouldTriggerStartEvent } from './should-trigger-start-event';
 
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
-	{ onClick, ...rest },
+type ExtendedLinkProps<RouteInferType = any> = LinkProps & {
+	className?: string;
+	children?: ReactNode;
+};
+
+export const Link = forwardRef<HTMLAnchorElement, ExtendedLinkProps>(function Link(
+	{ onClick, className, children, ...rest },
 	ref,
 ) {
 	return (
@@ -16,12 +21,14 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 				linkClicked(event);
 				if (onClick) onClick(event);
 			}}
+			className={className}
 			{...rest}
 			ref={ref}
-		/>
+		>
+			{children}
+		</NextLink>
 	);
 });
-
 export function linkClicked(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
 	const anchorElement = event.currentTarget as HTMLAnchorElement;
 	const { href } = anchorElement;


### PR DESCRIPTION
Hello sir Jay Simons  I really loved your solution which allowed me use Nprogress again after switching to the app router of NextJS 13 however, in using your solution I encountered a problem where Typescript  throws me an error when I try to pass in children to the Link component imported from `import { Link } from "nextjs13-progress";` because he Link component doesn't accept children or className by default as props so I simulated a solution by modifying the props and it worked just fine. Hence, I decided to created a PR with the solution in hopes that you could adopt it and updated the NPM package.

while in wait for an accepted PR from you,

Thanks a lot for the new solution.
