### PR TITLE
have added the target prop as well as other useful link props

### DIFF
--- a/src/lib/router-events/patch-router/link.tsx
+++ b/src/lib/router-events/patch-router/link.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import NextLink, { LinkProps } from 'next/link';
-import { forwardRef, ReactNode } from 'react';
+import React, { forwardRef, ReactNode, CSSProperties } from 'react';
 
 import { onStart } from '../events';
 import { shouldTriggerStartEvent } from './should-trigger-start-event';
@@ -9,10 +9,16 @@ import { shouldTriggerStartEvent } from './should-trigger-start-event';
 type ExtendedLinkProps<RouteInferType = any> = LinkProps & {
 	className?: string;
 	children?: ReactNode | string;
+	target?: React.HTMLAttributeAnchorTarget;
+	rel?: string;
+	style?: CSSProperties;
+	'aria-label'?: string;
+	id?: string;
+	[key: string]: any; // Allows additional data-* attributes
 };
 
 export const Link = forwardRef<HTMLAnchorElement, ExtendedLinkProps>(function Link(
-	{ onClick, className, children, ...rest },
+	{ onClick, className, children, target, rel, style, 'aria-label': ariaLabel, id, ...rest },
 	ref,
 ) {
 	return (
@@ -22,6 +28,11 @@ export const Link = forwardRef<HTMLAnchorElement, ExtendedLinkProps>(function Li
 				if (onClick) onClick(event);
 			}}
 			className={className}
+			target={target}
+			rel={rel}
+			style={style}
+			aria-label={ariaLabel}
+			id={id}
 			{...rest}
 			ref={ref}
 		>


### PR DESCRIPTION
I created this pull request to solve the issue when TS throws an error when we try to use the target prop on the patched link component. I also added other useful props one may need when working with this link element. 